### PR TITLE
Improve chart API response

### DIFF
--- a/app.py
+++ b/app.py
@@ -131,7 +131,10 @@ def index():
 def chat():
     user_msg = request.json.get('message', '').strip()
     if not user_msg:
-        return jsonify({'reply': '메시지를 입력해주세요.'})
+        return jsonify({'answer': '메시지를 입력해주세요.',
+                        'per': None,
+                        'roe': None,
+                        'debt_ratio': None})
 
     # 기본 투자 성향 저장 (실제 서비스에서는 사용자가 선택)
     profile = session.get('profile')
@@ -183,7 +186,7 @@ def chat():
 
     return jsonify(
         {
-            "reply": answer,
+            "answer": answer,
             "stock": stock_name,
             "per": per,
             "roe": roe,

--- a/static/js/script.js
+++ b/static/js/script.js
@@ -68,7 +68,7 @@ document.addEventListener('DOMContentLoaded', function() {
         .then(res => res.json())
         .then(data => {
             loader.remove();
-            addMessage(data.reply, 'bot');
+            addMessage(data.answer, 'bot');
             updateChart(data);
         })
         .catch(() => {

--- a/templates/index.html
+++ b/templates/index.html
@@ -2,6 +2,7 @@
 <html lang="ko">
 <head>
     <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>로보 어드바이저 Chat</title>
     <link rel="stylesheet" href="{{ url_for('static', filename='css/style.css') }}">
     <script src="https://cdn.jsdelivr.net/npm/chart.js"></script>


### PR DESCRIPTION
## Summary
- update `/chat` response to return `answer` field and stock metrics
- adjust client script to read `answer` field
- add viewport meta tag in template

## Testing
- `python -m py_compile app.py`
- `python app.py` *(fails: ModuleNotFoundError: No module named 'flask')*

------
https://chatgpt.com/codex/tasks/task_e_685730af94f4832fab38bee9648a3a27