### PR TITLE
Improve info panel visibility for stock chart

### DIFF
--- a/static/css/style.css
+++ b/static/css/style.css
@@ -53,6 +53,7 @@ body {
     flex-direction: column;
     justify-content: center;
     align-items: center;
+    height: 100%;
 }
 
 .message {
@@ -138,7 +139,7 @@ body {
 
 #stockChart {
     width: 100% !important;
-    height: 100% !important;
+    height: 250px !important;
 }
 
 @keyframes blink {


### PR DESCRIPTION
## Summary
- extend info panel height so it fills available space
- give the stock chart a fixed height so the chart is visible

## Testing
- `python -m py_compile app.py`

------
https://chatgpt.com/codex/tasks/task_e_685731ea5f50832fbbf31bcedcaf60e3