### PR TITLE
Show stock metrics via chart

### DIFF
--- a/app.py
+++ b/app.py
@@ -129,12 +129,17 @@ def index():
 
 @app.route('/chat', methods=['POST'])
 def chat():
-    user_msg = request.json.get('message', '').strip()
+    user_msg = request.json.get("message", "").strip()
     if not user_msg:
-        return jsonify({'answer': '메시지를 입력해주세요.',
-                        'per': None,
-                        'roe': None,
-                        'debt_ratio': None})
+        return jsonify(
+            {
+                "reply": "메시지를 입력해주세요.",
+                "stock_name": None,
+                "per": None,
+                "roe": None,
+                "debt_ratio": None,
+            }
+        )
 
     # 기본 투자 성향 저장 (실제 서비스에서는 사용자가 선택)
     profile = session.get('profile')
@@ -165,14 +170,8 @@ def chat():
         conn.close()
         if row:
             per = row["per"]
-            try:
-                roe = float(str(row["roe"]).replace("%", ""))
-            except ValueError:
-                roe = None
-            try:
-                debt_ratio = float(str(row["debt_ratio"]).replace("%", ""))
-            except ValueError:
-                debt_ratio = None
+            roe = row["roe"]
+            debt_ratio = row["debt_ratio"]
 
     try:
         response = client.chat.completions.create(
@@ -186,8 +185,8 @@ def chat():
 
     return jsonify(
         {
-            "answer": answer,
-            "stock": stock_name,
+            "reply": answer,
+            "stock_name": stock_name,
             "per": per,
             "roe": roe,
             "debt_ratio": debt_ratio,

--- a/static/js/script.js
+++ b/static/js/script.js
@@ -6,18 +6,21 @@ document.addEventListener('DOMContentLoaded', function() {
     let chart;
 
     function updateChart(info) {
-        if (!info || !info.stock) {
-            chartTitle.textContent = '종목을 선택하면 지표가 표시됩니다.';
+        if (!info || !info.stock_name) {
+            chartTitle.textContent = '해당 종목의 재무 지표를 찾을 수 없습니다';
             if (chart) { chart.destroy(); chart = null; }
             return;
         }
-        chartTitle.textContent = info.stock + ' 주요 지표';
+        chartTitle.textContent = info.stock_name + ' 주요 지표';
         const ctx = document.getElementById('stockChart').getContext('2d');
-        const values = [info.per, info.roe, info.debt_ratio];
+        const per = parseFloat(info.per);
+        const roe = parseFloat(String(info.roe).replace('%', ''));
+        const debt = parseFloat(String(info.debt_ratio).replace('%', ''));
+        const values = [per, roe, debt];
         const colors = [
-            info.per > 20 ? '#e74c3c' : '#4a76a8',
-            info.roe >= 15 ? '#2ecc71' : '#f1c40f',
-            info.debt_ratio > 50 ? '#e74c3c' : '#2ecc71'
+            per > 20 ? '#e74c3c' : '#4a76a8',
+            roe >= 15 ? '#2ecc71' : '#f1c40f',
+            debt > 50 ? '#e74c3c' : '#2ecc71'
         ];
         if (chart) chart.destroy();
         chart = new Chart(ctx, {
@@ -68,7 +71,7 @@ document.addEventListener('DOMContentLoaded', function() {
         .then(res => res.json())
         .then(data => {
             loader.remove();
-            addMessage(data.answer, 'bot');
+            addMessage(data.reply, 'bot');
             updateChart(data);
         })
         .catch(() => {


### PR DESCRIPTION
## Summary
- extend backend `/chat` to return stock metrics when a known stock is mentioned
- adjust frontend JS to update Chart.js bar chart with PER/ROE/debt ratio
- show a message when a stock's metrics are unavailable

## Testing
- `python -m py_compile app.py`
- `python -m py_compile $(git ls-files '*.py')`
- `python app.py` *(fails: ModuleNotFoundError: No module named 'flask')*

------
https://chatgpt.com/codex/tasks/task_e_685733df5bf4832f96d69bbf97fcae5d