### PR TITLE
Adjust layout to prevent clipping

### DIFF
--- a/static/css/style.css
+++ b/static/css/style.css
@@ -10,8 +10,10 @@ body {
     font-family: Arial, sans-serif;
     display: flex;
     justify-content: center;
-    align-items: center;
-    height: 100vh;
+    align-items: flex-start;
+    min-height: 100vh;
+    padding: 20px 0;
+    box-sizing: border-box;
 }
 
 .app-container {
@@ -20,14 +22,14 @@ body {
     display: grid;
     grid-template-columns: 1fr 320px;
     gap: 20px;
-    height: 100vh;
+    height: calc(100vh - 40px);
     overflow: hidden;
 }
 
 @media (max-width: 768px) {
     .app-container {
         grid-template-columns: 1fr;
-        height: 100vh;
+        height: calc(100vh - 40px);
     }
     .info-panel {
         height: 300px;


### PR DESCRIPTION
## Summary
- add padding to body to ensure margin top and bottom
- reduce app container height accordingly

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_685737d90ba0832f990ee28261bf2896