### PR TITLE
Fix bottom cut-off issue

### DIFF
--- a/static/css/style.css
+++ b/static/css/style.css
@@ -1,7 +1,8 @@
 html, body {
     height: 100%;
     margin: 0;
-    overflow: hidden;
+    overflow-x: hidden;
+    overflow-y: auto;
 }
 
 body {
@@ -12,7 +13,7 @@ body {
     justify-content: center;
     align-items: flex-start;
     min-height: 100vh;
-    padding: 20px 0;
+    padding: 20px 0 60px;
     box-sizing: border-box;
 }
 


### PR DESCRIPTION
## Summary
- enable vertical scrolling on the main page
- give the page extra bottom padding to avoid input cut-off on mobile

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68573891cbb8832f94d89db193f411ca