### PR TITLE
Fix layout for input visibility

### DIFF
--- a/static/css/style.css
+++ b/static/css/style.css
@@ -11,26 +11,33 @@ body {
     font-family: Arial, sans-serif;
     display: flex;
     justify-content: center;
-    align-items: flex-start;
+    align-items: stretch;
     min-height: 100vh;
-    padding: 20px 0 60px;
+    padding: 20px;
     box-sizing: border-box;
+}
+
+
+.layout {
+    width: 100%;
+    max-width: 1000px;
+    height: 100%;
+    display: grid;
+    grid-template-rows: 1fr auto;
+    gap: 20px;
 }
 
 .app-container {
     width: 100%;
-    max-width: 1000px;
     display: grid;
     grid-template-columns: 1fr 320px;
     gap: 20px;
-    height: calc(100vh - 80px);
     overflow: hidden;
 }
 
 @media (max-width: 768px) {
     .app-container {
         grid-template-columns: 1fr;
-        height: calc(100vh - 80px);
     }
     .info-panel {
         height: 300px;
@@ -109,6 +116,8 @@ body {
 
 .input-area {
     display: flex;
+    width: 100%;
+    box-sizing: border-box;
 }
 
 #userInput {

--- a/templates/index.html
+++ b/templates/index.html
@@ -7,17 +7,19 @@
     <link rel="stylesheet" href="{{ url_for('static', filename='css/style.css') }}">
 </head>
 <body>
-    <div class="app-container">
-        <div class="card chat-card">
-            <div id="chatHistory" class="chat-history"></div>
-            <div class="input-area">
-                <input type="text" id="userInput" placeholder="메시지를 입력하세요..." autocomplete="off">
-                <button id="sendBtn">전송</button>
+    <div class="layout">
+        <div class="app-container">
+            <div class="card chat-card">
+                <div id="chatHistory" class="chat-history"></div>
+            </div>
+            <div class="info-panel" id="infoPanel">
+                <h3 id="infoTitle">종목을 선택하면 지표가 표시됩니다.</h3>
+                <div id="metricContainer" class="metric-container"></div>
             </div>
         </div>
-        <div class="info-panel" id="infoPanel">
-            <h3 id="infoTitle">종목을 선택하면 지표가 표시됩니다.</h3>
-            <div id="metricContainer" class="metric-container"></div>
+        <div class="input-area">
+            <input type="text" id="userInput" placeholder="메시지를 입력하세요..." autocomplete="off">
+            <button id="sendBtn">전송</button>
         </div>
     </div>
     <script src="{{ url_for('static', filename='js/script.js') }}"></script>


### PR DESCRIPTION
## Summary
- refactor HTML structure to keep input at the bottom
- update CSS with grid layout so chat and info panels share screen height

## Testing
- `python -m py_compile app.py`
- `python app.py` *(fails: ModuleNotFoundError: No module named 'flask')*

------
https://chatgpt.com/codex/tasks/task_e_68573acdbd24832fadb4126dd92778d6