### PR TITLE
Fix layout scrolling issue

### DIFF
--- a/static/css/style.css
+++ b/static/css/style.css
@@ -1,8 +1,7 @@
 html, body {
     height: 100%;
     margin: 0;
-    overflow-x: hidden;
-    overflow-y: hidden;
+    overflow: hidden;
 }
 
 body {
@@ -12,7 +11,7 @@ body {
     display: flex;
     justify-content: center;
     align-items: stretch;
-    min-height: 100vh;
+    height: 100vh;
     padding: 20px;
     box-sizing: border-box;
 }
@@ -27,17 +26,18 @@ body {
     gap: 20px;
 }
 
-.app-container {
+
+.main-content {
     width: 100%;
-    display: grid;
-    grid-template-columns: 1fr 320px;
+    display: flex;
+    height: 100%;
     gap: 20px;
     overflow: hidden;
 }
 
 @media (max-width: 768px) {
-    .app-container {
-        grid-template-columns: 1fr;
+    .main-content {
+        flex-direction: column;
     }
     .info-panel {
         height: 300px;
@@ -52,6 +52,14 @@ body {
     height: 100%;
     display: flex;
     flex-direction: column;
+}
+
+
+.chat-area {
+    flex: 1;
+    display: flex;
+    flex-direction: column;
+    overflow: hidden;
 }
 
 .chat-history {
@@ -71,6 +79,7 @@ body {
     align-items: center;
     height: 100%;
     overflow-y: auto;
+    flex: 0 0 320px;
 }
 
 .message {

--- a/templates/index.html
+++ b/templates/index.html
@@ -8,8 +8,8 @@
 </head>
 <body>
     <div class="layout">
-        <div class="app-container">
-            <div class="card chat-card">
+        <div class="main-content">
+            <div class="chat-area chat-card">
                 <div id="chatHistory" class="chat-history"></div>
             </div>
             <div class="info-panel" id="infoPanel">


### PR DESCRIPTION
## Summary
- ensure body uses full viewport height without scrolling
- replace `.app-container` grid with flex-based `.main-content`
- add `.chat-area` wrapper and fix info panel width
- update HTML structure to match new classes

## Testing
- `pytest -q`
- `flake8 || true`

------
https://chatgpt.com/codex/tasks/task_e_6857689ab404832f9da06b6a8ce0ae0a