### PR TITLE
Add stock info panel

### DIFF
--- a/static/css/style.css
+++ b/static/css/style.css
@@ -83,6 +83,31 @@ body {
     flex: 0 0 320px;
 }
 
+#stock-info {
+    background: #1e1e1e;
+    color: #ffffff;
+    border-radius: 8px;
+    box-shadow: 0 0 10px rgba(0,0,0,0.5);
+    padding: 20px;
+    flex: 0 0 320px;
+    overflow-y: auto;
+}
+
+#stock-info ul {
+    padding-left: 20px;
+    margin-top: 10px;
+}
+
+#stock-info li {
+    margin-bottom: 4px;
+}
+
+@media (max-width: 768px) {
+    #stock-info {
+        height: 300px;
+    }
+}
+
 .message {
     max-width: 80%;
     padding: 12px 18px;

--- a/static/js/script.js
+++ b/static/js/script.js
@@ -4,6 +4,7 @@ document.addEventListener('DOMContentLoaded', () => {
     const chatHistory = document.getElementById('chatHistory');
     const infoTitle = document.getElementById('infoTitle');
     const metricContainer = document.getElementById('metricContainer');
+    const stockInfo = document.getElementById('stock-info');
 
     function interpret(metric, value) {
         let val = parseFloat(String(value).replace(/[^0-9.-]/g, ''));
@@ -69,6 +70,25 @@ document.addEventListener('DOMContentLoaded', () => {
         });
     }
 
+    function updateRightPanel(info) {
+        stockInfo.innerHTML = '';
+        if (!info) return;
+        let html = '';
+        if (info.name) {
+            html += `<h3>${info.name}</h3>`;
+        }
+        if (info.summary) {
+            html += `<p>${info.summary}</p>`;
+        }
+        if (info.description) {
+            html += `<p>${info.description}</p>`;
+        }
+        if (info.products && info.products.length) {
+            html += '<ul>' + info.products.map(p => `<li>${p}</li>`).join('') + '</ul>';
+        }
+        stockInfo.innerHTML = html;
+    }
+
     function addMessage(text, sender) {
         const div = document.createElement('div');
         div.className = 'message ' + sender;
@@ -106,6 +126,7 @@ document.addEventListener('DOMContentLoaded', () => {
                 addMessage(`주요 제품: ${data.main_products}`, 'bot');
             }
             updateMetrics(data);
+            updateRightPanel(data.stock_info || null);
         })
         .catch(() => {
             loader.remove();

--- a/templates/index.html
+++ b/templates/index.html
@@ -16,6 +16,7 @@
                 <h3 id="infoTitle">종목을 선택하면 지표가 표시됩니다.</h3>
                 <div id="metricContainer" class="metric-container"></div>
             </div>
+            <div id="stock-info"></div>
         </div>
         <div class="input-area">
             <input type="text" id="userInput" placeholder="메시지를 입력하세요..." autocomplete="off">


### PR DESCRIPTION
## Summary
- add `build_stock_info` helper for company info
- include `stock_info` in `/chat` JSON response
- show new right panel in HTML layout
- render stock information via JS
- style new panel for dark theme

## Testing
- `python -m py_compile app.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68577b612570832f8bbe74f51032089b