### PR TITLE
Refactor layout to two column design

### DIFF
--- a/static/css/style.css
+++ b/static/css/style.css
@@ -17,43 +17,23 @@ body {
 }
 
 
-.layout {
+.wrapper {
     width: 100%;
     max-width: 1000px;
     height: 100%;
-    display: grid;
-    grid-template-rows: 1fr auto;
-    gap: 20px;
-}
-
-
-.main-content {
-    width: 100%;
     display: flex;
-    height: 100%;
     gap: 20px;
-    overflow: hidden;
 }
 
-@media (max-width: 768px) {
-    .main-content {
-        flex-direction: column;
-    }
-    .info-panel {
-        height: 300px;
-    }
-}
-
-.chat-card {
+.chat-panel {
     background: #1e1e1e;
     border-radius: 8px;
     box-shadow: 0 0 10px rgba(0,0,0,0.5);
     padding: 20px;
-    height: 100%;
     display: flex;
     flex-direction: column;
+    flex: 0 0 60%;
 }
-
 
 .chat-area {
     flex: 1;
@@ -68,29 +48,16 @@ body {
     margin-bottom: 10px;
 }
 
-.info-panel {
-    background: #1e1e1e;
-    border-radius: 8px;
-    box-shadow: 0 0 10px rgba(0,0,0,0.5);
-    padding: 20px;
-    display: flex;
-    flex-direction: column;
-    justify-content: flex-start;
-    align-items: center;
-    height: 100%;
-    max-height: 100%;
-    overflow-y: auto;
-    flex: 0 0 320px;
-}
-
 #stock-info {
     background: #1e1e1e;
     color: #ffffff;
     border-radius: 8px;
     box-shadow: 0 0 10px rgba(0,0,0,0.5);
     padding: 20px;
-    flex: 0 0 320px;
+    flex: 0 0 40%;
     overflow-y: auto;
+    display: flex;
+    flex-direction: column;
 }
 
 #stock-info ul {
@@ -102,11 +69,6 @@ body {
     margin-bottom: 4px;
 }
 
-@media (max-width: 768px) {
-    #stock-info {
-        height: 300px;
-    }
-}
 
 .message {
     max-width: 80%;
@@ -153,6 +115,7 @@ body {
     display: flex;
     width: 100%;
     box-sizing: border-box;
+    margin-top: 10px;
 }
 
 #userInput {
@@ -160,6 +123,8 @@ body {
     padding: 10px;
     border-radius: 4px;
     border: none;
+    resize: none;
+    height: 60px;
 }
 
 #sendBtn {

--- a/static/js/script.js
+++ b/static/js/script.js
@@ -5,6 +5,7 @@ document.addEventListener('DOMContentLoaded', () => {
     const infoTitle = document.getElementById('infoTitle');
     const metricContainer = document.getElementById('metricContainer');
     const stockInfo = document.getElementById('stock-info');
+    const stockDetails = document.getElementById('stockDetails');
 
     function interpret(metric, value) {
         let val = parseFloat(String(value).replace(/[^0-9.-]/g, ''));
@@ -71,12 +72,9 @@ document.addEventListener('DOMContentLoaded', () => {
     }
 
     function updateRightPanel(info) {
-        stockInfo.innerHTML = '';
+        stockDetails.innerHTML = '';
         if (!info) return;
         let html = '';
-        if (info.name) {
-            html += `<h3>${info.name}</h3>`;
-        }
         if (info.summary) {
             html += `<p>${info.summary}</p>`;
         }
@@ -86,7 +84,7 @@ document.addEventListener('DOMContentLoaded', () => {
         if (info.products && info.products.length) {
             html += '<ul>' + info.products.map(p => `<li>${p}</li>`).join('') + '</ul>';
         }
-        stockInfo.innerHTML = html;
+        stockDetails.innerHTML = html;
     }
 
     function addMessage(text, sender) {

--- a/templates/index.html
+++ b/templates/index.html
@@ -7,20 +7,20 @@
     <link rel="stylesheet" href="{{ url_for('static', filename='css/style.css') }}">
 </head>
 <body>
-    <div class="layout">
-        <div class="main-content">
-            <div class="chat-area chat-card">
+    <div class="wrapper">
+        <div class="chat-panel">
+            <div class="chat-area">
                 <div id="chatHistory" class="chat-history"></div>
+                <div class="input-area">
+                    <textarea id="userInput" placeholder="메시지를 입력하세요..." autocomplete="off"></textarea>
+                    <button id="sendBtn">전송</button>
+                </div>
             </div>
-            <div class="info-panel" id="infoPanel">
-                <h3 id="infoTitle">종목을 선택하면 지표가 표시됩니다.</h3>
-                <div id="metricContainer" class="metric-container"></div>
-            </div>
-            <div id="stock-info"></div>
         </div>
-        <div class="input-area">
-            <input type="text" id="userInput" placeholder="메시지를 입력하세요..." autocomplete="off">
-            <button id="sendBtn">전송</button>
+        <div id="stock-info" class="stock-panel">
+            <h3 id="infoTitle">종목을 선택하면 지표가 표시됩니다.</h3>
+            <div id="metricContainer" class="metric-container"></div>
+            <div id="stockDetails"></div>
         </div>
     </div>
     <script src="{{ url_for('static', filename='js/script.js') }}"></script>


### PR DESCRIPTION
## Summary
- set up main wrapper as flexbox
- place chat and stock panels side-by-side
- allow chat history to fill height and stock information panel to contain metrics and details
- adjust script to write stock details into dedicated container

## Testing
- `python -m py_compile app.py`

------
https://chatgpt.com/codex/tasks/task_e_68577dceeab8832faf2121edcf1c9090