### PR TITLE
Add stock detail display

### DIFF
--- a/static/css/style.css
+++ b/static/css/style.css
@@ -69,6 +69,11 @@ body {
     margin-bottom: 4px;
 }
 
+.stock-summary {
+    color: #cccccc;
+    font-size: 0.85em;
+}
+
 
 .message {
     max-width: 80%;

--- a/static/js/script.js
+++ b/static/js/script.js
@@ -73,10 +73,16 @@ document.addEventListener('DOMContentLoaded', () => {
 
     function updateRightPanel(info) {
         stockDetails.innerHTML = '';
-        if (!info) return;
+        if (!info) {
+            stockDetails.textContent = '종목 정보를 찾을 수 없습니다.';
+            return;
+        }
         let html = '';
+        if (info.name) {
+            html += `<h2>${info.name}</h2>`;
+        }
         if (info.summary) {
-            html += `<p>${info.summary}</p>`;
+            html += `<span class="stock-summary">${info.summary}</span>`;
         }
         if (info.description) {
             html += `<p>${info.description}</p>`;


### PR DESCRIPTION
## Summary
- show stock details with name, summary, description and products in the right panel
- display message when no stock information is available
- style summary text as small gray text

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_685780a80380832fad99d93c45d47dc1